### PR TITLE
Fix flipped alt and ctrl conditions

### DIFF
--- a/windows/autohotkey/ijkl.ahk
+++ b/windows/autohotkey/ijkl.ahk
@@ -5,18 +5,18 @@ SetCapsLockState, AlwaysOff
 CapsLock & i::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{Up}
-    else if GetKeyState("Ctrl", "D")
         Send +!{Up}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{Up}
     else
         Send +{Up}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{Up}
     else
-        Send !{Up}
+        Send ^{Up}
 else if GetKeyState("Alt", "D")
-    Send ^{Up}
+    Send !{Up}
 else
     Send {Up}
 return
@@ -24,18 +24,18 @@ return
 CapsLock & k::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{Down}
-    else if GetKeyState("Ctrl", "D")
         Send +!{Down}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{Down}
     else
         Send +{Down}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{Down}
     else
-        Send !{Down}
+        Send ^{Down}
 else if GetKeyState("Alt", "D")
-    Send ^{Down}
+    Send !{Down}
 else
     Send {Down}
 return
@@ -43,18 +43,18 @@ return
 CapsLock & j::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{Left}
-    else if GetKeyState("Ctrl", "D")
         Send +!{Left}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{Left}
     else
         Send +{Left}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{Left}
     else
-        Send !{Left}
+        Send ^{Left}
 else if GetKeyState("Alt", "D")
-    Send ^{Left}
+    Send !{Left}
 else
     Send {Left}
 return
@@ -62,18 +62,18 @@ return
 CapsLock & l::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{Right}
-    else if GetKeyState("Ctrl", "D")
         Send +!{Right}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{Right}
     else
         Send +{Right}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{Right}
     else
-        Send !{Right}
+        Send ^{Right}
 else if GetKeyState("Alt", "D")
-    Send ^{Right}
+    Send !{Right}
 else
     Send {Right}
 return
@@ -81,18 +81,18 @@ return
 CapsLock & u::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{Home}
-    else if GetKeyState("Ctrl", "D")
         Send +!{Home}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{Home}
     else
         Send +{Home}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{Home}
     else
-        Send !{Home}
+        Send ^{Home}
 else if GetKeyState("Alt", "D")
-    Send ^{Home}
+    Send !{Home}
 else
     Send {Home}
 return
@@ -100,18 +100,18 @@ return
 CapsLock & o::
 if GetKeyState("Shift", "D")
     if GetKeyState("Alt", "D")
-        Send +^{End}
-    else if GetKeyState("Ctrl", "D")
         Send +!{End}
+    else if GetKeyState("Ctrl", "D")
+        Send +^{End}
     else
         Send +{End}
 else if GetKeyState("Ctrl", "D")
     if (GetKeyState("Alt", "D"))
         Send !^{End}
     else
-        Send !{End}
+        Send ^{End}
 else if GetKeyState("Alt", "D")
-    Send ^{End}
+    Send !{End}
 else
     Send {End}
 return


### PR DESCRIPTION
Hi, I used your script but noticed that all "alts" and "ctrls" are flipped, when I started using key combinations. Please check for yourself and if happy, feel free to apply these changes. 